### PR TITLE
✨ Extends awstETH LM Lido

### DIFF
--- a/tests/20241104_LMUpdateAaveV3EthereumLido_ExtendsWstETHLM/AaveV3EthereumLido_LMUpdateExtendsWstETHLM_20241104.t.sol
+++ b/tests/20241104_LMUpdateAaveV3EthereumLido_ExtendsWstETHLM/AaveV3EthereumLido_LMUpdateExtendsWstETHLM_20241104.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3EthereumLido_LMUpdateExtendsWstETHLM_20241104 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 5.25 * 10 ** 18;
+
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3EthereumLido.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
+  address public constant awstETH_WHALE = 0xfCf1Dd2D209AEB1323Dd9A0F2ea65187C84d6c8a;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3EthereumLido.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21114006);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      awstETH_WHALE,
+      AaveV3EthereumLidoAssets.wstETH_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      0.0107 * 5.25 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      block.timestamp + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241104_LMUpdateAaveV3EthereumLido_ExtendsWstETHLM/config.ts
+++ b/tests/20241104_LMUpdateAaveV3EthereumLido_ExtendsWstETHLM/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3EthereumLido',
+    title: 'Extends wstETH LM',
+    shortName: 'ExtendsWstETHLM',
+    date: '20241104',
+  },
+  poolOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumLidoAssets.wstETH_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'wstETH_aToken',
+          distributionEnd: '7',
+          rewardAmount: '5.25',
+          whaleAddress: '0xd412107354ccD6e103443372946C985F31B09e5c',
+          whaleExpectedReward: '0.05',
+        },
+      },
+      cache: {blockNumber: 21113789},
+    },
+  },
+};

--- a/tests/utils/LMBaseTest.sol
+++ b/tests/utils/LMBaseTest.sol
@@ -71,6 +71,10 @@ abstract contract LMBaseTest is Test {
     );
     uint256 balanceAfter = IERC20(this.REWARD_ASSET()).balanceOf(whale);
 
+    emit log_named_uint('balanceBefore', balanceBefore);
+    emit log_named_uint('balanceAfter', balanceAfter);
+    emit log_named_uint('expectedReward', expectedReward);
+
     assertApproxEqRel(
       balanceAfter - balanceBefore,
       expectedReward, // Approx estimated rewards with current emissions


### PR DESCRIPTION
## Recap 
- Renew Ethereum Lido awstETH LM
- Config:
  - asset rewarded:
    - awstETH
  - reward asset:
    - awstETH 
  - duration: 7 days
  - new emission: 5.25 (-50% of last emission of 10.5 ETH per week)

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/6a0384db-76dd-498a-9a42-ff503f296b21/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b538000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c2000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c2000000000000000000000000000000000000000000000000000000006731eb47```

- `newEmissionPerSecond`
  - ```0xf996868b000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c2000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000007e5196e2ae3```