### PR TITLE
✨ Renew aUSDC Lido LM

### DIFF
--- a/tests/20241105_LMUpdateAaveV3EthereumLido_RenewAUSDCLido/AaveV3EthereumLido_LMUpdateRenewAUSDCLido_20241105.t.sol
+++ b/tests/20241105_LMUpdateAaveV3EthereumLido_RenewAUSDCLido/AaveV3EthereumLido_LMUpdateRenewAUSDCLido_20241105.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3EthereumLido_LMUpdateRenewAUSDCLido_20241105 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 3.71 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3EthereumLido.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 26 days;
+  address public constant aUSDC_WHALE = 0xD11e845a3cFe69c88b6c1e36b1e933bc49373f29;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3EthereumLido.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21122093);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDC_WHALE,
+      AaveV3EthereumLidoAssets.USDC_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      0.04 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumLidoAssets.USDC_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumLidoAssets.USDC_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      block.timestamp + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241105_LMUpdateAaveV3EthereumLido_RenewAUSDCLido/config.ts
+++ b/tests/20241105_LMUpdateAaveV3EthereumLido_RenewAUSDCLido/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3EthereumLido',
+    title: 'Renew aUSDC Lido',
+    shortName: 'RenewAUSDCLido',
+    date: '20241105',
+  },
+  poolOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumLidoAssets.wstETH_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDC_aToken',
+          distributionEnd: '26',
+          rewardAmount: '3.71',
+          whaleAddress: '0xD11e845a3cFe69c88b6c1e36b1e933bc49373f29',
+          whaleExpectedReward: '0.04',
+        },
+      },
+      cache: {blockNumber: 21122093},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew Ethereum Lido aUSDC LM
- Config:
  - asset rewarded:
    - aUSDC
  - reward asset:
    - awstETH 
  - duration: 26 days
  - new emission: 3.71 wstETH

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/1e5bb48f-5de5-441c-b35b-e3e4872496f5/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b5380000000000000000000000002a1fbcb52ed4d9b23dad17e1e8aed4bb0e6079b8000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c200000000000000000000000000000000000000000000000000000000674c74c7```

- `newEmissionPerSecond`
  - ```0xf996868b0000000000000000000000002a1fbcb52ed4d9b23dad17e1e8aed4bb0e6079b8000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000018086f05517```