### PR TITLE
✨ Renew USDS LM

### DIFF
--- a/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106.t.sol
+++ b/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106.t.sol
@@ -11,13 +11,13 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106 is LMUpdateBaseTest {
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
-  address public constant aUSDS_WHALE = 0x18740A8020dC029B7b8156a7aF8Bd951B65029B0;
+  address public constant aUSDS_WHALE = 0x3FB5f37b0071ef4FCB9487Bb2F8cf37cC6bf2e0D;
 
   address public constant override DEFAULT_INCENTIVES_CONTROLLER =
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 21124604);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21124949);
   }
 
   function test_claimRewards() public {
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106 is LMUpdateBaseTest {
       aUSDS_WHALE,
       AaveV3EthereumAssets.USDS_A_TOKEN,
       NEW_DURATION_DISTRIBUTION_END,
-      1712.69 * 10 ** 18
+      788.536491 * 10 ** 18
     );
   }
 

--- a/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106.t.sol
+++ b/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241106 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 159979 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
+  address public constant aUSDS_WHALE = 0x18740A8020dC029B7b8156a7aF8Bd951B65029B0;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21124604);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDS_WHALE,
+      AaveV3EthereumAssets.USDS_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      1712.69 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      block.timestamp + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
+++ b/tests/20241106_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3Ethereum',
+    title: 'Renew USDS LM',
+    shortName: 'RenewUSDSLM',
+    date: '20241106',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumAssets.USDS_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDS_aToken',
+          distributionEnd: '7',
+          rewardAmount: '159979',
+          whaleAddress: '0x18740A8020dC029B7b8156a7aF8Bd951B65029B0',
+          whaleExpectedReward: '1712.69',
+        },
+      },
+      cache: {blockNumber: 21124604},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew Ethereum aUSDS LM
- Config:
  - asset rewarded:
    - aUSDS
  - reward asset:
    - aUSDS 
  - duration: 7 days
  - new emission: 159979 USDS

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/1079239e-aaaf-4f22-8e71-74ccaa4a565c/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b53800000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000006733eedb```

- `newEmissionPerSecond`
  - ```0xf996868b00000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000003abbf7bfa086358```