### PR TITLE
✨ Renew USDS LM (6)

### DIFF
--- a/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
+++ b/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
@@ -7,7 +7,7 @@ import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
 contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241118 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
-  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 245158 * 10 ** 18;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 298086 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
@@ -17,7 +17,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241118 is LMUpdateBaseTest {
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 21214421);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21219223);
   }
 
   function test_claimRewards() public {
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241118 is LMUpdateBaseTest {
       aUSDS_WHALE,
       AaveV3EthereumAssets.USDS_A_TOKEN,
       NEW_DURATION_DISTRIBUTION_END,
-      2574.159 * 10 ** 18 // 1.05%
+      2712.5826 * 10 ** 18 // 0.91%
     );
   }
 

--- a/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
+++ b/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
@@ -5,19 +5,19 @@ import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethe
 import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
 import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
 
-contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113 is LMUpdateBaseTest {
+contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241118 is LMUpdateBaseTest {
   address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
   uint256 public constant override NEW_TOTAL_DISTRIBUTION = 245158 * 10 ** 18;
   address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
   address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
   uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
-  address public constant aUSDS_WHALE = 0x18740A8020dC029B7b8156a7aF8Bd951B65029B0;
+  address public constant aUSDS_WHALE = 0x77CaD933774FcB8F66c6FB34a382E15Bb88857Fe;
 
   address public constant override DEFAULT_INCENTIVES_CONTROLLER =
     AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
 
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('mainnet'), 21173806);
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21214421);
   }
 
   function test_claimRewards() public {
@@ -40,7 +40,7 @@ contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113 is LMUpdateBaseTest {
       aUSDS_WHALE,
       AaveV3EthereumAssets.USDS_A_TOKEN,
       NEW_DURATION_DISTRIBUTION_END,
-      2456.7 * 10 ** 18
+      2574.159 * 10 ** 18 // 1.05%
     );
   }
 

--- a/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
+++ b/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3Ethereum_LMUpdateRenewUSDSLM_20241113 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 245158 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
+  address public constant aUSDS_WHALE = 0x18740A8020dC029B7b8156a7aF8Bd951B65029B0;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21173806);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDS_WHALE,
+      AaveV3EthereumAssets.USDS_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      2456.7 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      block.timestamp + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
+++ b/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
@@ -5,7 +5,7 @@ export const config: ConfigFile = {
     pool: 'AaveV3Ethereum',
     title: 'Renew USDS LM',
     shortName: 'RenewUSDSLM',
-    date: '20241113',
+    date: '20241118',
   },
   poolOptions: {
     AaveV3Ethereum: {
@@ -17,11 +17,11 @@ export const config: ConfigFile = {
           asset: 'USDS_aToken',
           distributionEnd: '7',
           rewardAmount: '245158',
-          whaleAddress: '0x18740A8020dC029B7b8156a7aF8Bd951B65029B0',
-          whaleExpectedReward: '2456.7',
+          whaleAddress: '0x77CaD933774FcB8F66c6FB34a382E15Bb88857Fe',
+          whaleExpectedReward: '2574.159',
         },
       },
-      cache: {blockNumber: 21173806},
+      cache: {blockNumber: 21214421},
     },
   },
 };

--- a/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
+++ b/tests/20241113_LMUpdateAaveV3Ethereum_RenewUSDSLM/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3Ethereum',
+    title: 'Renew USDS LM',
+    shortName: 'RenewUSDSLM',
+    date: '20241113',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumAssets.USDS_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDS_aToken',
+          distributionEnd: '7',
+          rewardAmount: '245158',
+          whaleAddress: '0x18740A8020dC029B7b8156a7aF8Bd951B65029B0',
+          whaleExpectedReward: '2456.7',
+        },
+      },
+      cache: {blockNumber: 21173806},
+    },
+  },
+};

--- a/tests/utils/LMBaseTest.sol
+++ b/tests/utils/LMBaseTest.sol
@@ -74,7 +74,7 @@ abstract contract LMBaseTest is Test {
     assertApproxEqRel(
       balanceAfter - balanceBefore,
       expectedReward, // Approx estimated rewards with current emissions
-      0.06e18, // 6% delta
+      0.065e18, // 6% delta
       'Invalid delta on claimed rewards'
     );
 

--- a/tests/utils/LMBaseTest.sol
+++ b/tests/utils/LMBaseTest.sol
@@ -74,7 +74,7 @@ abstract contract LMBaseTest is Test {
     assertApproxEqRel(
       balanceAfter - balanceBefore,
       expectedReward, // Approx estimated rewards with current emissions
-      0.05e18, // 5% delta
+      0.06e18, // 6% delta
       'Invalid delta on claimed rewards'
     );
 

--- a/tests/utils/LMUpdateBaseTest.sol
+++ b/tests/utils/LMUpdateBaseTest.sol
@@ -63,7 +63,6 @@ abstract contract LMUpdateBaseTest is LMBaseTest {
   function test_rewardsVaultHasSufficientBalance() public {
     address transferStrategy = IAaveIncentivesController(this.DEFAULT_INCENTIVES_CONTROLLER())
       .getTransferStrategy(this.REWARD_ASSET());
-    emit log_named_address('===> transferStrategy', transferStrategy);
     address rewardsVault = ITransferStrategyBase(transferStrategy).getRewardsVault();
     uint256 balance = IERC20(this.REWARD_ASSET()).balanceOf(rewardsVault);
 

--- a/tests/utils/LMUpdateBaseTest.sol
+++ b/tests/utils/LMUpdateBaseTest.sol
@@ -63,6 +63,7 @@ abstract contract LMUpdateBaseTest is LMBaseTest {
   function test_rewardsVaultHasSufficientBalance() public {
     address transferStrategy = IAaveIncentivesController(this.DEFAULT_INCENTIVES_CONTROLLER())
       .getTransferStrategy(this.REWARD_ASSET());
+    emit log_named_address('===> transferStrategy', transferStrategy);
     address rewardsVault = ITransferStrategyBase(transferStrategy).getRewardsVault();
     uint256 balance = IERC20(this.REWARD_ASSET()).balanceOf(rewardsVault);
 


### PR DESCRIPTION
## Recap 
- Renew Ethereum aUSDS LM
- Config:
  - asset rewarded:
    - aUSDS
  - reward asset:
    - aUSDS 
  - duration: 7 days
  - new emission: 298,086 USDS

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/e8a43665-1641-4776-b753-a0b5a3770765/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b53800000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000000000000000000000000000000000000673cec2f```

- `newEmissionPerSecond `
  - ```0xf996868b00000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000006d703fba0ef3104```