### PR TITLE
✨ Renew Lido Instance aUSDC LM

### DIFF
--- a/tests/20241129_LMUpdateAaveV3EthereumLido_RenewAUSDCLM/AaveV3EthereumLido_LMUpdateRenewAUSDCLM_20241129.t.sol
+++ b/tests/20241129_LMUpdateAaveV3EthereumLido_RenewAUSDCLM/AaveV3EthereumLido_LMUpdateRenewAUSDCLM_20241129.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy, IRewardsController} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3EthereumLido_LMUpdateRenewAUSDCLM_20241129 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumLidoAssets.wstETH_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 3.71 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3EthereumLido.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 24 days;
+  address public constant aUSDC_WHALE = 0x6c4d27d3aE62B6C1eAa9b732377F7Ddf3cF2B1E6;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3EthereumLido.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21294155);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDC_WHALE,
+      AaveV3EthereumLidoAssets.USDC_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      0.04 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumLidoAssets.USDC_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumLidoAssets.USDC_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      IRewardsController(AaveV3EthereumLido.DEFAULT_INCENTIVES_CONTROLLER).getDistributionEnd(
+        newDistributionEndPerAsset.asset,
+        newDistributionEndPerAsset.reward
+      ) + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241129_LMUpdateAaveV3EthereumLido_RenewAUSDCLM/config.ts
+++ b/tests/20241129_LMUpdateAaveV3EthereumLido_RenewAUSDCLM/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3EthereumLido',
+    title: 'Renew aUSDC LM',
+    shortName: 'RenewAUSDCLM',
+    date: '20241129',
+  },
+  poolOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumLidoAssets.wstETH_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDC_aToken',
+          distributionEnd: '24',
+          rewardAmount: '3.71',
+          whaleAddress: '0x6c4d27d3aE62B6C1eAa9b732377F7Ddf3cF2B1E6',
+          whaleExpectedReward: '0.04',
+        },
+      },
+      cache: {blockNumber: 21294155},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew Lido Instance aWETH LM
- Config:
  - asset rewarded:
    - aUSDC
  - reward asset:
    - awstETH 
  - duration: 24 days
  - new emission: 3.71 aWETH

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/6431491f-a2e5-4e78-9e56-9751f3e4156c/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b5380000000000000000000000002a1fbcb52ed4d9b23dad17e1e8aed4bb0e6079b8000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c200000000000000000000000000000000000000000000000000000000676c18c7```

- `newEmissionPerSecond `
  - ```0xf996868b0000000000000000000000002a1fbcb52ed4d9b23dad17e1e8aed4bb0e6079b8000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c035a7cf15375ce2706766804551791ad035e0c20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000001a0922f06d9```