### PR TITLE
✨ Renew aweth lido lm

### DIFF
--- a/tests/20241218_LMUpdateAaveV3EthereumLido_RenewAEthLidoWethLM/AaveV3EthereumLido_LMUpdateRenewAEthLidoWethLM_20241218.t.sol
+++ b/tests/20241218_LMUpdateAaveV3EthereumLido_RenewAEthLidoWethLM/AaveV3EthereumLido_LMUpdateRenewAEthLidoWethLM_20241218.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3EthereumLido_LMUpdateRenewAEthLidoWethLM_20241218 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumLidoAssets.WETH_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 107.5 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3EthereumLido.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 21 days;
+  address public constant aWETH_WHALE = 0x6AF235d2Bbe050e6291615B71CA5829658810142;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3EthereumLido.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21428530);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3EthereumLido.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aWETH_WHALE,
+      AaveV3EthereumLidoAssets.WETH_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      1.13 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumLidoAssets.WETH_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumLidoAssets.WETH_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      block.timestamp + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20241218_LMUpdateAaveV3EthereumLido_RenewAEthLidoWethLM/config.ts
+++ b/tests/20241218_LMUpdateAaveV3EthereumLido_RenewAEthLidoWethLM/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3EthereumLido',
+    title: 'Renew aEthLidoWeth LM',
+    shortName: 'RenewAEthLidoWethLM',
+    date: '20241218',
+  },
+  poolOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumLidoAssets.WETH_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'WETH_aToken',
+          distributionEnd: '21',
+          rewardAmount: '107.5',
+          whaleAddress: '0x6AF235d2Bbe050e6291615B71CA5829658810142',
+          whaleExpectedReward: '1.13',
+        },
+      },
+      cache: {blockNumber: 21428530},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew aEthLidoWeth LM
- Config:
  - asset rewarded:
    - aEthLidoWeth
  - reward asset:
    - aEthLidoWeth 
  - duration: 21 days
  - new emission: 107.5 aEthLidoWeth

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/71f37a12-67e6-4410-95ad-aad0ffbbc449/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b538000000000000000000000000fa1fdbbd71b0aa16162d76914d69cd8cb3ef92da000000000000000000000000fa1fdbbd71b0aa16162d76914d69cd8cb3ef92da00000000000000000000000000000000000000000000000000000000677e458b```

- `newEmissionPerSecond `
  - ```0xf996868b000000000000000000000000fa1fdbbd71b0aa16162d76914d69cd8cb3ef92da000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001000000000000000000000000fa1fdbbd71b0aa16162d76914d69cd8cb3ef92da0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000035e2ce148231```