### PR TITLE
✨ Renew USDS LM 16

### DIFF
--- a/tests/20250127_LMUpdateAaveV3Ethereum_RenewUSDSLM16/AaveV3Ethereum_LMUpdateRenewUSDSLM16_20250127.t.sol
+++ b/tests/20250127_LMUpdateAaveV3Ethereum_RenewUSDSLM16/AaveV3Ethereum_LMUpdateRenewUSDSLM16_20250127.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IEmissionManager, ITransferStrategyBase, RewardsDataTypes, IEACAggregatorProxy, IRewardsController} from '../../src/interfaces/IEmissionManager.sol';
+import {LMUpdateBaseTest} from '../utils/LMUpdateBaseTest.sol';
+
+contract AaveV3Ethereum_LMUpdateRenewUSDSLM16_20250127 is LMUpdateBaseTest {
+  address public constant override REWARD_ASSET = AaveV3EthereumAssets.USDS_A_TOKEN;
+  uint256 public constant override NEW_TOTAL_DISTRIBUTION = 538958 * 10 ** 18;
+  address public constant override EMISSION_ADMIN = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  address public constant override EMISSION_MANAGER = AaveV3Ethereum.EMISSION_MANAGER;
+  uint256 public constant NEW_DURATION_DISTRIBUTION_END = 7 days;
+  address public constant aUSDS_WHALE = 0xA701b1315168F2CD290c3F3df3427e88E946f91c;
+
+  address public constant override DEFAULT_INCENTIVES_CONTROLLER =
+    AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21717655);
+  }
+
+  function test_claimRewards() public {
+    NewEmissionPerAsset memory newEmissionPerAsset = _getNewEmissionPerSecond();
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset = _getNewDistributionEnd();
+
+    vm.startPrank(EMISSION_ADMIN);
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setEmissionPerSecond(
+      newEmissionPerAsset.asset,
+      newEmissionPerAsset.rewards,
+      newEmissionPerAsset.newEmissionsPerSecond
+    );
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setDistributionEnd(
+      newDistributionEndPerAsset.asset,
+      newDistributionEndPerAsset.reward,
+      newDistributionEndPerAsset.newDistributionEnd
+    );
+
+    _testClaimRewardsForWhale(
+      aUSDS_WHALE,
+      AaveV3EthereumAssets.USDS_A_TOKEN,
+      NEW_DURATION_DISTRIBUTION_END,
+      5605.96 * 10 ** 18
+    );
+  }
+
+  function _getNewEmissionPerSecond() internal pure override returns (NewEmissionPerAsset memory) {
+    NewEmissionPerAsset memory newEmissionPerAsset;
+
+    address[] memory rewards = new address[](1);
+    rewards[0] = REWARD_ASSET;
+    uint88[] memory newEmissionsPerSecond = new uint88[](1);
+    newEmissionsPerSecond[0] = _toUint88(NEW_TOTAL_DISTRIBUTION / NEW_DURATION_DISTRIBUTION_END);
+
+    newEmissionPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newEmissionPerAsset.rewards = rewards;
+    newEmissionPerAsset.newEmissionsPerSecond = newEmissionsPerSecond;
+
+    return newEmissionPerAsset;
+  }
+
+  function _getNewDistributionEnd()
+    internal
+    view
+    override
+    returns (NewDistributionEndPerAsset memory)
+  {
+    NewDistributionEndPerAsset memory newDistributionEndPerAsset;
+
+    newDistributionEndPerAsset.asset = AaveV3EthereumAssets.USDS_A_TOKEN;
+    newDistributionEndPerAsset.reward = REWARD_ASSET;
+    newDistributionEndPerAsset.newDistributionEnd = _toUint32(
+      IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER).getDistributionEnd(
+        newDistributionEndPerAsset.asset,
+        newDistributionEndPerAsset.reward
+      ) + NEW_DURATION_DISTRIBUTION_END
+    );
+
+    return newDistributionEndPerAsset;
+  }
+}

--- a/tests/20250127_LMUpdateAaveV3Ethereum_RenewUSDSLM16/config.ts
+++ b/tests/20250127_LMUpdateAaveV3Ethereum_RenewUSDSLM16/config.ts
@@ -1,0 +1,27 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    feature: 'UPDATE_LM',
+    pool: 'AaveV3Ethereum',
+    title: 'Renew USDS LM 16',
+    shortName: 'RenewUSDSLM16',
+    date: '20250127',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        UPDATE_LM: {
+          emissionsAdmin: '0xac140648435d03f784879cd789130F22Ef588Fcd',
+          rewardToken: 'AaveV3EthereumAssets.USDS_A_TOKEN',
+          rewardTokenDecimals: 18,
+          asset: 'USDS_aToken',
+          distributionEnd: '7',
+          rewardAmount: '538958',
+          whaleAddress: '0xA701b1315168F2CD290c3F3df3427e88E946f91c',
+          whaleExpectedReward: '5605.96',
+        },
+      },
+      cache: {blockNumber: 21717655},
+    },
+  },
+};


### PR DESCRIPTION
## Recap 
- Renew Ethereum aUSDS LM
- Config:
  - asset rewarded:
    - aUSDS
  - reward asset:
    - aUSDS 
  - duration: 7 days
  - new emission: 538,958 USDS (https://etherscan.io/tx/0x53767bc3f1158c8fecfa970eb1872bc2addfdf134e08ab8c2671a5f2e33d354c)

## Simulation on Tenderly (Safe batch)

https://dashboard.tenderly.co/public/safe/safe-apps/simulator/b78984a5-012b-4e1a-aa51-912b09f900b0/logs

## Calldatas

- `newDistributionEnd`
  - ```0xc5a7b53800000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000032a6268f9ba3642dda7892add74f1d34469a42590000000000000000000000000000000000000000000000000000000067a2d430```

- `newEmissionPerSecond `
  - ```0xf996868b00000000000000000000000032a6268f9ba3642dda7892add74f1d34469a4259000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000032a6268f9ba3642dda7892add74f1d34469a425900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000c5df1e32a54397b```